### PR TITLE
Add checks for children elements

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -36,7 +36,7 @@ export default class Handorgel extends EventEmitter {
       const content = children[i + 1]
       let fold = header.handorgelFold
 
-      if (!fold) {
+      if (!fold && header && content) {
         fold = new Fold(this, header, content)
       }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -38,9 +38,8 @@ export default class Handorgel extends EventEmitter {
 
       if (!fold && header && content) {
         fold = new Fold(this, header, content)
+        this.folds.push(fold)
       }
-
-      this.folds.push(fold)
     }
   }
 


### PR DESCRIPTION
I've added additional checks for Handorgel child elements to prevent a JS error when adding an additional element to the structure.

For example I had this structure which throwed an error:

```html
  <h3 class="handorgel__header">
    <button class="handorgel__header__button" autofocus>
      Title (autofocused)
    </button>
  </h3>
  <div class="handorgel__content" data-open>
    <div class="handorgel__content__inner">
      Content openened by default
    </div>
  </div>
  <h3 class="handorgel__header">
    <button class="handorgel__header__button">
      Title 2
    </button>
  </h3>
  <div class="handorgel__content">
    <div class="handorgel__content__inner">
      Content closed by default
    </div>
  </div>
  <div class="handorgel__last-border"></div>
</div>
```

I've added an additional element since it's not possible to add a border after header, which should be visible after the content when expanded.