### PR TITLE
setTimeout for rAF function

### DIFF
--- a/src/js/fold.js
+++ b/src/js/fold.js
@@ -117,9 +117,12 @@ export default class HandorgelFold {
       const height = this.content.firstElementChild.offsetHeight
       this.content.style.height = `${height}px`
 
-      rAF(() => {
-        this.content.style.height = '0px'
-      })
+      setTimeout( function()
+      {
+        rAF(function () {
+          _this.content.style.height = '0px';
+        });
+      }, 100);
     }
   }
 


### PR DESCRIPTION
Here is a fix for the issue [--open classes don't always get removed when a handorgel closes #18](https://github.com/oncode/handorgel/issues/18)

If you set a minimal timeout for the animation function, closing folds work like expected in firefox.
